### PR TITLE
Windows support

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2021 Avindra Goolcharan <avindra@opensuse.org>
+Copyright (c) 2017-2025 Avindra Goolcharan <avindra@opensuse.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/main.go
+++ b/main.go
@@ -33,6 +33,8 @@ func main() {
 				switch args[1] {
 				case "fish":
 					dirp.PrintFishHook()
+				case "pwsh":
+					dirp.PrintPwshHook()
 				case "es":
 					dirp.PrintEsHook()
 				case "rc":

--- a/src/hook.go
+++ b/src/hook.go
@@ -2,6 +2,7 @@ package dirp
 
 import (
 	"embed"
+	"os"
 )
 
 //go:embed hooks/*
@@ -10,23 +11,23 @@ var folder embed.FS
 // PrintHook emits shell code for Bash, ZSH, sh, BusyBox, etc
 func PrintHook() {
 	hook, _ := folder.ReadFile("hooks/hook.sh")
-	print(string(hook))
+	os.Stdout.Write(hook)
 }
 
 // PrintFishHook emits shell code for Fish
 func PrintFishHook() {
 	hook, _ := folder.ReadFile("hooks/hook.fish")
-	print(string(hook))
+	os.Stdout.Write(hook)
 }
 
 // PrintRcHook emits code for rc, the plan 9 shell
 func PrintRcHook() {
 	hook, _ := folder.ReadFile("hooks/hook.rc")
-	print(string(hook))
+	os.Stdout.Write(hook)
 }
 
 // PrintEsHook emits code for es, a shell based on rc
 func PrintEsHook() {
 	hook, _ := folder.ReadFile("hooks/hook.es")
-	print(string(hook))
+	os.Stdout.Write(hook)
 }

--- a/src/hook.go
+++ b/src/hook.go
@@ -1,113 +1,32 @@
 package dirp
 
 import (
-	"fmt"
-	"strings"
+	"embed"
 )
+
+//go:embed hooks/*
+var folder embed.FS
 
 // PrintHook emits shell code for Bash, ZSH, sh, BusyBox, etc
 func PrintHook() {
-	// 1) Remove existing "dir" aliases, if any exist
-	// 2) Detect and prefer pushd over cd
-	// 3) Provide "dir" function
-	// 4) export dir function for Bash users
-
-	// important: do not use $status as a variable
-	// because it's a readonly reserved special var in ZSH
-	fmt.Println(`
-unalias dir >/dev/null 2>&1
-
-_DIRP_CD=cd
-type pushd >/dev/null 2>&1 && _DIRP_CD=pushd
-
-dir () {
-		stdout=$(dirp $@)
-		stat=$?
-		if [ -n $stdout ]; then
-			if [ $stat -eq 2 ]; then
-				$EDITOR "$stdout"
-				return $?
-			fi
-
-			echo "Switching to $stdout... "
-			$_DIRP_CD "$stdout"
-		fi
-	}
-
-	alias d=dir
-	alias d.="dir ."
-	alias d..="dir .."
-
-	export -f dir >/dev/null 2>&1
-	`)
+	hook, _ := folder.ReadFile("hooks/hook.sh")
+	print(string(hook))
 }
 
 // PrintFishHook emits shell code for Fish
 func PrintFishHook() {
-	fmt.Println(`
-
-	function dir
-		set stdout (dirp $argv)
-		if [ $status = 2 ]
-			$EDITOR "$stdout"
-			return $status
-		end
-	
-		if [ "x$stdout" = "x" ]
-			echo -n "How are we doing @ "
-			uptime
-			return $status
-		end
-	
-		echo "Switching to $stdout"
-		pushd "$stdout"
-	end
-
-	abbr -a -g d dir
-	abbr -a -g d. dir .
-	abbr -a -g d.. dir ..
-
-	`)
+	hook, _ := folder.ReadFile("hooks/hook.fish")
+	print(string(hook))
 }
 
 // PrintRcHook emits code for rc, the plan 9 shell
 func PrintRcHook() {
-	src := `fn dir {
-		stdout=` + "`" + `{dirp $*};
-		if (~ $bqstatus 2 ) {
-			$EDITOR $stdout;
-			return $status;
-		};
-	
-		if (~ "x$stdout" "x" ) {
-			echo -n How are we doing @;
-			uptime;
-			return $status;
-		};
-	
-		echo Switching to $stdout;
-		cd $stdout
-	}`
-
-	fmt.Println(strings.ReplaceAll(src, "\t", "  "))
+	hook, _ := folder.ReadFile("hooks/hook.rc")
+	print(string(hook))
 }
 
 // PrintEsHook emits code for es, a shell based on rc
 func PrintEsHook() {
-	fmt.Println(`fn dir {
-	stdout=` + "`" + `{dirp $*};
-	if {~ $bqstatus 2 } {
-		$EDITOR $stdout;
-		return $status;
-	};
-	
-	if {~ "x$stdout" "x" } {
-		echo -n "How are we doing @";
-		uptime;
-		return $status;
-	};
-	
-	echo Switching to $stdout; 
-	cd $stdout
-}`)
+	hook, _ := folder.ReadFile("hooks/hook.es")
+	print(string(hook))
 }

--- a/src/hook.go
+++ b/src/hook.go
@@ -31,3 +31,9 @@ func PrintEsHook() {
 	hook, _ := folder.ReadFile("hooks/hook.es")
 	os.Stdout.Write(hook)
 }
+
+// PrintPwshHook emits code for PowerShell
+func PrintPwshHook() {
+	hook, _ := folder.ReadFile("hooks/hook.pwsh")
+	os.Stdout.Write(hook)
+}

--- a/src/hooks/hook.es
+++ b/src/hooks/hook.es
@@ -1,0 +1,16 @@
+fn dir {
+	stdout=` + "`" + `{dirp $*};
+	if {~ $bqstatus 2 } {
+		$EDITOR $stdout;
+		return $status;
+	};
+	
+	if {~ "x$stdout" "x" } {
+		echo -n "How are we doing @";
+		uptime;
+		return $status;
+	};
+	
+	echo Switching to $stdout; 
+	cd $stdout
+}

--- a/src/hooks/hook.fish
+++ b/src/hooks/hook.fish
@@ -1,0 +1,20 @@
+function dir
+    set stdout (dirp $argv)
+    if [ $status = 2 ]
+        $EDITOR "$stdout"
+        return $status
+    end
+
+    if [ "x$stdout" = x ]
+        echo -n "How are we doing @ "
+        uptime
+        return $status
+    end
+
+    echo "Switching to $stdout"
+    pushd "$stdout"
+end
+
+abbr -a -g d dir
+abbr -a -g d. dir .
+abbr -a -g d.. dir ..

--- a/src/hooks/hook.pwsh
+++ b/src/hooks/hook.pwsh
@@ -1,0 +1,16 @@
+Remove-Alias dir
+
+function dir {
+	$dir = dirp @args
+
+	if ($LASTEXITCODE -eq 2) {
+		notepad $dir
+	}
+
+	pushd $dir
+}
+
+
+Set-Alias -Name d -Value dir
+#Set-Alias -Name d. -Value dir .
+#Set-Alias -Name d.. -Value dir ..

--- a/src/hooks/hook.rc
+++ b/src/hooks/hook.rc
@@ -1,0 +1,16 @@
+fn dir {
+	stdout=` + "`" + `{dirp $*};
+	if (~ $bqstatus 2 ) {
+		$EDITOR $stdout;
+		return $status;
+	};
+
+	if (~ "x$stdout" "x" ) {
+		echo -n How are we doing @;
+		uptime;
+		return $status;
+	};
+	
+	echo Switching to $stdout;
+	cd $stdout
+}

--- a/src/hooks/hook.sh
+++ b/src/hooks/hook.sh
@@ -1,0 +1,32 @@
+# 1) Remove existing "dir" aliases, if any exist
+# 2) Detect and prefer pushd over cd
+# 3) Provide "dir" function
+# 4) export dir function for Bash users
+
+# important: do not use $status as a variable
+# because it's a readonly reserved special var in ZSH
+
+unalias dir >/dev/null 2>&1
+
+_DIRP_CD=cd
+type pushd >/dev/null 2>&1 && _DIRP_CD=pushd
+
+dir () {
+	stdout=$(dirp $@)
+	stat=$?
+	if [ -n $stdout ]; then
+		if [ $stat -eq 2 ]; then
+			$EDITOR "$stdout"
+			return $?
+		fi
+
+		echo "Switching to $stdout... "
+		$_DIRP_CD "$stdout"
+	fi
+}
+
+alias d=dir
+alias d.="dir ."
+alias d..="dir .."
+
+export -f dir >/dev/null 2>&1

--- a/src/proc.go
+++ b/src/proc.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -16,22 +17,21 @@ func IsDir(path string) bool {
 	return fileInfo.IsDir()
 }
 
-// FindDirs at path
+// FindDirs at path. Used by driller
 
 func FindDirs(path string) ConfigSelection {
-	dir, err := os.Open(path)
+	fullPath, _ := filepath.Abs(path)
+	dir, err := os.Open(fullPath)
 	if err != nil {
 		return nil
 	}
 
-	names, err := dir.Readdirnames(-1)
-	if err != nil {
-		return nil
-	}
+	names, _ := dir.Readdirnames(-1)
+	defer dir.Close()
 
 	cfg := make(ConfigSelection, len(names))
 	for k := range names {
-		if !IsDir(names[k]) {
+		if !IsDir(filepath.Join(fullPath, names[k])) {
 			continue
 		}
 

--- a/src/proc.go
+++ b/src/proc.go
@@ -31,11 +31,12 @@ func FindDirs(path string) ConfigSelection {
 
 	cfg := make(ConfigSelection, len(names))
 	for k := range names {
-		if !IsDir(filepath.Join(fullPath, names[k])) {
+		resolvedPath := filepath.Join(fullPath, names[k])
+		if !IsDir(resolvedPath) {
 			continue
 		}
 
-		D := names[k]
+		D := resolvedPath
 		cfg[D] = D
 	}
 	return cfg

--- a/src/proc.go
+++ b/src/proc.go
@@ -29,15 +29,12 @@ func FindDirs(path string) ConfigSelection {
 	names, _ := dir.Readdirnames(-1)
 	defer dir.Close()
 
-	cfg := make(ConfigSelection, len(names))
-	for k := range names {
-		resolvedPath := filepath.Join(fullPath, names[k])
-		if !IsDir(resolvedPath) {
-			continue
+	cfg := make(ConfigSelection)
+	for _, name := range names {
+		resolvedPath := filepath.Join(fullPath, name)
+		if IsDir(resolvedPath) {
+			cfg[resolvedPath] = resolvedPath
 		}
-
-		D := resolvedPath
-		cfg[D] = D
 	}
 	return cfg
 }

--- a/src/proc.go
+++ b/src/proc.go
@@ -16,25 +16,26 @@ func IsDir(path string) bool {
 	return fileInfo.IsDir()
 }
 
-// execFindDir at the given path
-// "-mindepth 1" is used to excl working dir
-// https://superuser.com/a/590470/59068
-func execFindDir(path string) string {
-	routine := []string{"find", path, "-mindepth", "1", "-maxdepth", "1", "-type", "d"}
-	result, err := execWith(strings.NewReader(""), routine)
+// FindDirs at path
+
+func FindDirs(path string) ConfigSelection {
+	dir, err := os.Open(path)
 	if err != nil {
-		return ""
+		return nil
 	}
 
-	return result
-}
+	names, err := dir.Readdirnames(-1)
+	if err != nil {
+		return nil
+	}
 
-// FindDirs at path
-func FindDirs(path string) ConfigSelection {
-	dirs := strings.Split(execFindDir(path), "\n")
-	cfg := make(ConfigSelection, len(dirs))
-	for k := range dirs {
-		D := dirs[k]
+	cfg := make(ConfigSelection, len(names))
+	for k := range names {
+		if !IsDir(names[k]) {
+			continue
+		}
+
+		D := names[k]
 		cfg[D] = D
 	}
 	return cfg


### PR DESCRIPTION
This will enable usage on Windows (#5) in addition to
possible speedup from not needing to fork.

### Changes:

* [x] Implement FindDirs using go std lib replacing findutils
* [x] Stub out PowerShell hook
* [x] Embed hooks as files (introduced in go 1.16)

### How to use the hook?

Like so:

```pwsh
dirp hook pwsh | Out-String | iex
```

This is documented thrice:

* https://github.com/avindra/dotfiles/commit/1cc8160cabb5509392c3f8c41d3ddb8d4d94a38a
* https://github.com/avindra/dirp/wiki/Shell
* https://github.com/avindra/dirp/releases/tag/0.7.0